### PR TITLE
Reverts usage of submodules for iotagent-node-lib

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,1 @@
-[submodule "third-party/iotagent-node-lib"]
-	path = third-party/iotagent-node-lib
-	url = ../../iotagent-node-lib
-	branch = 2d5469
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,7 @@ ARG NODEJS_VERSION=
 COPY . /opt/iotajson/
 WORKDIR /opt/iotajson
 
-ENV NODE_PATH="${NODE_PATH}:/opt/iotajson/third-party"
-
-RUN cd /opt/iotajson && npm install --production && cd /opt/iotajson/third-party/iotagent-node-lib/ && npm install --production
+RUN npm install --production
 
 ENTRYPOINT bin/iotagent-json config.js
-
 EXPOSE 4041
-

--- a/package.json
+++ b/package.json
@@ -2,17 +2,17 @@
   "name": "iotagent-json",
   "description": "IoT Agent for the JSON protocol",
   "version": "1.5.0-next",
-  "homepage": "https://github.com/telefonicaid/iotagent-json",
+  "homepage": "https://github.com/dojot/iotagent-json",
   "author": {
     "name": "Daniel Moran",
     "email": "dmj@tid.es"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/telefonicaid/iotagent-json.git"
+    "url": "git://github.com/dojot/iotagent-json.git"
   },
   "bugs": {
-    "url": "https://github.com/telefonicaid/iotagent-json/issues"
+    "url": "https://github.com/dojot/iotagent-json/issues"
   },
   "main": "lib/iotagent-json",
   "engines": {
@@ -54,6 +54,7 @@
     "logops": "1.0.0-alpha.7",
     "mqtt": "1.10.0",
     "request": "2.72.0",
-    "underscore": "1.8.3"
+    "underscore": "1.8.3",
+    "iotagent-node-lib": "git://github.com/dojot/iotagent-node-lib.git#cpqd_master"
   }
 }


### PR DESCRIPTION
Now that we're on github, there's no need for the submodule and custom install instructions. So I'm removing them in favor of npm's github integration.