### PR TITLE
Adding timestamps defined by device

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -5,7 +5,7 @@ import mqttHandler = require("./mqtt-handler");
 import jsonpatch = require("../src/jsonpatch")
 import { ConfigOptions } from "./config";
 import { tokenize } from "./tools";
-import { DataBroker } from "./data-broker";
+import { DataBroker , MetaAttribute} from "./data-broker";
 import { IdResolver, CacheHandler } from "./cache";
 import { resolve } from "url";
 
@@ -88,6 +88,11 @@ class Agent {
       console.log("... message translated.");
     }
 
+    let metaData: MetaAttribute = { };
+    if (messageObj["TimeInstant"] != undefined) {
+      metaData.TimeInstant = messageObj["TimeInstant"];
+    }
+
     let filteredObj: any = {};
     // Message matches default message structure
     for (let attr in messageObj) {
@@ -107,7 +112,7 @@ class Agent {
     console.log("Service: " + deviceData.meta.service);
     console.log("Data: ");
     console.log(util.inspect(filteredObj, {depth: null}));
-    this.dataBroker.updateData(deviceData.meta.service, id, filteredObj);
+    this.dataBroker.updateData(deviceData.meta.service, id, filteredObj, metaData);
   }
 
   /**

--- a/src/data-broker.ts
+++ b/src/data-broker.ts
@@ -1,10 +1,15 @@
 
+interface MetaAttribute {
+  TimeInstant?: string
+}
+
 // Data broker interface
 interface DataBroker {
   host: string;
 
   // sends data to remote interested parties
-  updateData(service: string, deviceId: string, attributes: any): void;
+  updateData(service: string, deviceId: string, attributes: any, metaAttributes: MetaAttribute): void;
 }
 
 export {DataBroker};
+export {MetaAttribute};

--- a/src/kafka-handler.ts
+++ b/src/kafka-handler.ts
@@ -1,6 +1,6 @@
 import config = require("./config");
 import util = require("util");
-import {DataBroker} from "./data-broker";
+import {DataBroker, MetaAttribute} from "./data-broker";
 import kafka = require("kafka-node");
 import { DeviceManagerEvent } from "./cache";
 
@@ -115,12 +115,21 @@ class KafkaHandler implements DataBroker {
   }
 
   // sends received device event to configured kafka topic
-  updateData(service: string, deviceId: string, attributes: any) {
+  updateData(service: string, deviceId: string, attributes: any, metaAttributes: MetaAttribute) {
     if (this.isProducerReady === false) {
       console.log("Kafka producer is not yet ready.");
       return;
     }
     
+    if (metaAttributes.TimeInstant != undefined) {
+      for (let attr of attributes) {
+        // Only timestamp will be updated for now
+        attr["meta"] = {
+          TimeInstant: metaAttributes.TimeInstant
+        }
+      }
+    }
+
     let updateData: any = {
       "metadata": {
         "deviceid": deviceId,

--- a/src/orion-handler.ts
+++ b/src/orion-handler.ts
@@ -1,7 +1,7 @@
 import config = require("./config");
 import request = require("request");
 import util = require("util");
-import {DataBroker} from "./data-broker";
+import {DataBroker, MetaAttribute} from "./data-broker";
 
 class OrionHandler implements DataBroker {
   host: string;
@@ -20,12 +20,26 @@ class OrionHandler implements DataBroker {
     }
   }
 
-  updateData(service: string, deviceId: string, attributes: any) {
+  updateData(service: string, deviceId: string, attributes: any, metaAttributes: MetaAttribute) {
     let updateData: any = { }
 
-    for (let attr in attributes) {
-      updateData[attr] = {
-        "value": attributes[attr]
+    
+    if (metaAttributes.TimeInstant != undefined) {
+      for (let attr in attributes) {
+        updateData[attr] = {
+          "value": attributes[attr],
+          "metadata": {
+            "name" : "TimeInstant",
+            "type": "ISO8601",
+            "value" : metaAttributes.TimeInstant
+          }
+        }
+      }
+    } else {
+      for (let attr in attributes) {
+        updateData[attr] = {
+          "value": attributes[attr]
+        }
       }
     }
 


### PR DESCRIPTION
This PR implements support for timestamps defined by the device itself. This allows devices to send its readings in batches.


This implements dojot/iotagent-json#13