### PR TITLE
Update EJBCA sign url

### DIFF
--- a/certUtils.py
+++ b/certUtils.py
@@ -140,7 +140,7 @@ def signCert(EJBCA_API_URL, csrFile, CName, passwd):
         "certificate": cutDownCLR
     })
 
-    response = requests.post(EJBCA_API_URL + "/user/" + CName + "/pkcs10",
+    response = requests.post(EJBCA_API_URL + "/sign/" + CName + "/pkcs10",
                              headers=defaultHeader, data=req)
 
     if response.status_code == 200:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 cd /opt/iotagent-json/
 
-if [ "$MQTT_TLS" == "true"] ; then
+if [ "$MQTT_TLS" = "true" ] ; then
   python initialConf.py
   if [ $? -ne 0 ]; then
       echo "Error ocurred on initial iotagent TLS setup"


### PR DESCRIPTION
Updated the sign URL for the new EJBCA-REST version.
Also fix a typo on MQTT_TLS flag check.

This PR is related to dojot/dojot#153