### PR TITLE
Set the entrypoint script as entrypoint instead of a command

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,4 +12,4 @@ RUN npm install && npm run-script build
 RUN chmod +x /opt/iotagent-json/entrypoint.sh \
     && mkdir /opt/iotagent-json/certs
 
-CMD ["/opt/iotagent-json/entrypoint.sh"]
+ENTRYPOINT ["/opt/iotagent-json/entrypoint.sh"]


### PR DESCRIPTION
- Improves the usage of the container
- Set parameters via containers args