### PR TITLE
Implements usage of managed topics

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,8 +13,8 @@
     }
   },
   "broker": {
-    "host": "orion:1026",
-    "type": "orion"
+    "host": "zookeeper:2181",
+    "type": "kafka"
   },
   "device_manager": {
     "kafkaHost" : "zookeeper:2181",

--- a/config.json
+++ b/config.json
@@ -19,12 +19,10 @@
     "contextBroker": "http://data-broker"
   },
   "device_manager": {
-    "kafkaHost" : "zookeeper:2181",
-    "kafkaOptions": {
-      "autoCommit": true,
-      "fetchMaxWaitMs" : 1000,
-      "fetchMaxBytes" : 1048576,
-      "groupId" : "iotagent"
+    "consumerOptions": {
+      "kafkaHost" : "kafka:9092",
+      "sessionTimeout": 15000,
+      "groupId": "iotagent"
     },
     "inputSubject": "dojot.device-manager.device"
   }

--- a/config.json
+++ b/config.json
@@ -14,7 +14,9 @@
   },
   "broker": {
     "host": "zookeeper:2181",
-    "type": "kafka"
+    "type": "kafka",
+    "subject": "device-data",
+    "contextBroker": "http://data-broker"
   },
   "device_manager": {
     "kafkaHost" : "zookeeper:2181",
@@ -24,8 +26,6 @@
       "fetchMaxBytes" : 1048576,
       "groupId" : "iotagent"
     },
-    "kafkaTopics": [
-        { "topic": "dojot.device-manager.device" }
-      ]
+    "inputSubject": "dojot.device-manager.device"
   }
 }

--- a/config.json
+++ b/config.json
@@ -25,5 +25,14 @@
       "groupId": "iotagent"
     },
     "inputSubject": "dojot.device-manager.device"
+  },
+  "tenancy": {
+    "manager": "http://auth:5000",
+    "subject": "dojot.tenancy",
+    "consumerOptions": {
+      "kafkaHost" : "kafka:9092",
+      "sessionTimeout": 15000,
+      "groupId": "iotagent"
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -143,6 +143,15 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
+    "axios": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+      "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+      "requires": {
+        "follow-redirects": "1.4.1",
+        "is-buffer": "1.1.6"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -447,6 +456,24 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
+    "follow-redirects": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
+      "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+      "requires": {
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -681,6 +708,11 @@
         "is-relative": "0.2.1",
         "is-windows": "0.2.0"
       }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-extendable": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "keywords": [],
   "dependencies": {
+    "axios": "^0.17.1",
     "js-base64": "^2.3.2",
     "kafka-node": "^2.3.0",
     "mqtt": "^1.14.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,17 +56,29 @@ interface BrokerOptions {
   // Broker type.
   // Default value is "orion".
   type?: "orion" | "kafka";
+
+  ////
+  // Options for kafka broker
+  ////
+  // subject to be used when publishing received data. Defaults to 'device-data'
+  subject?: string;
+  // address of the context broker that manages kafka. Defaults to 'data-broker'
+  contextBroker?: string;
 }
 
 // Device manager options
 interface DeviceManagerOptions {
-  // This is which kakfa node is used by device manager to 
+  // This is which kakfa node is used by device manager to
   // broadcast its devices updates.
   kafkaHost: string;
   kafkaOptions: KafkaOptions;
+
   // Topics used by device manager to send notifications
   // about devices
-  kafkaTopics: KafkaTopic[];
+  // kafkaTopics: KafkaTopic[];
+
+  // subject used to receive asynch notifications from deviceManager
+  inputSubject: string;
 }
 // Main configuration structure
 interface ConfigOptions {

--- a/src/config.ts
+++ b/src/config.ts
@@ -75,6 +75,15 @@ interface DeviceManagerOptions {
   // subject used to receive asynch notifications from deviceManager
   inputSubject: string;
 }
+
+interface TenancyOptions {
+  // subject to use to receive tenancy lifecycle
+  subject: string;
+  // options to pass on to kafka client when creating connection
+  consumerOptions: KafkaOptions;
+  //
+  manager: string;
+}
 // Main configuration structure
 interface ConfigOptions {
   // MQTT options.
@@ -83,6 +92,8 @@ interface ConfigOptions {
   broker: BrokerOptions;
   // Device manager options
   device_manager: DeviceManagerOptions;
+  // Tenancy management options
+  tenancy: TenancyOptions;
 }
 
 export {ConfigOptions};

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,9 +41,11 @@ interface KafkaTopic {
 
 // Kafka configuration
 interface KafkaOptions {
-  autoCommit: boolean;
-  fetchMaxWaitMs: number;
-  fetchMaxBytes: number;
+  // Kafka location
+  kafkaHost: string;
+  // Session timeout - shorter timeouts lead to quicker failure detection, at a higher broker
+  // overhead cost.
+  sessionTimeout: number;
   // Kafka group ID
   groupId: string;
 }
@@ -68,15 +70,8 @@ interface BrokerOptions {
 
 // Device manager options
 interface DeviceManagerOptions {
-  // This is which kakfa node is used by device manager to
-  // broadcast its devices updates.
-  kafkaHost: string;
-  kafkaOptions: KafkaOptions;
-
-  // Topics used by device manager to send notifications
-  // about devices
-  // kafkaTopics: KafkaTopic[];
-
+  // Configurations for kafka consumer
+  consumerOptions: KafkaOptions;
   // subject used to receive asynch notifications from deviceManager
   inputSubject: string;
 }

--- a/src/data-broker.ts
+++ b/src/data-broker.ts
@@ -5,8 +5,6 @@ interface MetaAttribute {
 
 // Data broker interface
 interface DataBroker {
-  host: string;
-
   // sends data to remote interested parties
   updateData(service: string, deviceId: string, attributes: any, metaAttributes: MetaAttribute): void;
 }

--- a/src/kafka-handler.ts
+++ b/src/kafka-handler.ts
@@ -9,8 +9,8 @@ import { DeviceManagerEvent } from "./cache";
  * Class responsible for Kafka messaging
  */
 export class KafkaHandler implements DataBroker {
-  // Broker IP address and port.
-  host: string;
+
+  private config: config.ConfigOptions
 
   // Maps tenants to services to kafka topics
   topicMap: {[tenant: string]: {[service: string]:string}};
@@ -21,115 +21,179 @@ export class KafkaHandler implements DataBroker {
   private producer: kafka.HighLevelProducer;
   private isProducerReady: boolean;
 
-  // Main consumer.
-  private consumer: kafka.HighLevelConsumer;
+  // Main consumer (device management information).
+  private consumer: kafka.ConsumerGroup;
+  private dataCallback: (data: DeviceManagerEvent) => void
+  private topics: string[];
+
+  private tenancyConsumer: kafka.ConsumerGroup;
 
   /**
    * @param config The configuration to be used.
    * @param callback A callback that will process received device manager notifications
    */
   constructor(config: config.ConfigOptions, callback: (data: DeviceManagerEvent) => void) {
-    // Block any communication before producer is properly created.
-    this.isProducerReady = false;
-    this.initKafkaConfiguration(config, callback, "producer");
 
     if (config.broker.type == 'kafka') {
-      this.contextBroker = config.broker.contextBroker ? config.broker.contextBroker : 'data-broker';
+      this.contextBroker = config.broker.contextBroker ? config.broker.contextBroker : 'http://data-broker';
       this.publishingSubject = config.broker.subject ? config.broker.subject : 'device-data';
-      this.topicMap = {};
     }
+
+    this.dataCallback = callback;
+    this.config = config;
+
+    this.topicMap = {};
+    this.topics = [];
+
+    // Block any communication before producer is properly created.
+    this.isProducerReady = false;
+    this.initDataProducer();
+    this.initTenantWatcher();
+
+  }
+
+  private bootstrapTenants() {
+    axios({
+      'url': this.config.tenancy.manager + '/admin/tenants',
+      'method': 'get'
+    }).then((response: AxiosResponse) => {
+      for (let tenant of response.data.tenants) {
+        console.log('bootstraping for tenant', tenant);
+        this.initDeviceConsumer(tenant);
+      }
+    }).catch((error: AxiosError) => {
+      console.error('Failed to retrieve list of existing tenants');
+    })
+  }
+
+  private initTenantWatcher() {
+    this.getPublishTopic('internal', this.config.tenancy.subject, (err?:any, topic?: string) => {
+      if (err || (topic == undefined)) {
+        console.error('Failed to retrieve tenancy management topic', err);
+        process.exit(1);
+      }
+
+      this.tenancyConsumer = new kafka.ConsumerGroup(this.config.device_manager.consumerOptions, topic!);
+      console.log('... Tenancy consumer ready');
+      this.bootstrapTenants();
+
+      // Kafka consumer events registration
+      this.tenancyConsumer.on("message", (data) => {
+        let parsedData = JSON.parse(data.value.toString());
+        this.initDeviceConsumer(parsedData.tenant);
+      });
+      this.tenancyConsumer.on("error", (err) => {
+        console.log("Closing current consumer.");
+        this.consumer.close(true, (e) => {
+          console.log("Result of consumer close operation: " + e);
+          process.exit(1)
+        });
+      });
+
+      console.log("... Kafka tenancy consumer created and callbacks registered.");
+    }, true);
+  }
+
+  private initDeviceConsumer(tenant: string) {
+    let isScheduled = false;
+    console.log("Creating new Kafka client...");
+    // First try
+    // Creating consumer client - from device manager to iotagent.
+    // This is always used.
+    console.log("Creating Kafka device watcher...");
+    this.getPublishTopic(tenant, this.config.device_manager.inputSubject, (err?:any, topic?: string) => {
+      if (err || (topic == undefined)) {
+        console.error('Failed to retrieve input topic');
+        process.exit(1);
+      }
+
+      if (this.consumer){
+        this.consumer.close(true, (err) => {});
+      }
+      this.topics.unshift(topic!);
+      this.consumer = new kafka.ConsumerGroup(this.config.device_manager.consumerOptions, this.topics);
+      console.log('... device watcher is ready');
+
+      // Kafka consumer events registration
+      this.consumer.on("message", (data) => {
+        let parsedData = JSON.parse(data.value.toString());
+        this.dataCallback(parsedData);
+      });
+      this.consumer.on("error", (err) => {
+        if (isScheduled == true) {
+          console.log("An operation was already scheduled. No need to do it again.");
+          return;
+        }
+        console.log("Closing current consumer.");
+        this.consumer.close(true, (e) => {
+          console.log("Result of consumer close operation: " + e);
+        });
+
+        isScheduled = true;
+        console.log("Error: ", err);
+        console.log("Will try again to create Kafka consumer in a few seconds.");
+        setTimeout(() => {
+          console.log("Trying again.");
+          this.initDeviceConsumer(tenant);
+        }, 10000)
+      });
+
+      console.log("... Kafka device watcher created and callbacks registered.");
+    });
   }
 
   /**
-   * Start Kafka configuration.
+   * Start Kafka producer.
    *
    * If the producer creation fails, it will be tried again after one second.
    * TODO make retry period (or even attempt) configurable
    *
-   * @param config   The configuration being used.
    * @param client   Kafka clinet
-   * @param callback The callback to be invoked when a device manager event is received.
    */
-  private initKafkaConfiguration(config: config.ConfigOptions, callback: (data: DeviceManagerEvent) => void, type: string) {
+  private initDataProducer() {
     let isScheduled = false;
-    switch (type) {
-      case "producer":
-        if (config.broker.type === "kafka") {
-          console.log("Creating Kafka producer...");
-          let client = new kafka.Client(config.broker.host, "iotagent-json-producer-" +  Math.floor(Math.random() * 10000));
-          console.log("... Kafka client for producer is ready.");
-          console.log("Creating Kafka producer...");
-          this.producer = new kafka.HighLevelProducer(client, { requireAcks: 1 });
+    if (this.config.broker.type === "kafka") {
+      console.log("Creating Kafka producer...");
+      let client = new kafka.Client(this.config.broker.host, "iotagent-json-producer-" +  Math.floor(Math.random() * 10000));
+      console.log("... Kafka client for producer is ready.");
+      this.producer = new kafka.HighLevelProducer(client, { requireAcks: 1 });
 
-          // Kafka producer events registration
-          this.producer.on("ready", () => {
-            console.log("... Kafka producer creation finished.");
-            this.isProducerReady = true;
-            this.initKafkaConfiguration(config, callback, "consumer");
-          });
-          this.producer.on("error", (e) => {
-            if (isScheduled == true) {
-              console.log("An operation was already scheduled. No need to do it again.");
-              return;
-            }
-            this.producer.close();
-            isScheduled = true;
-            console.error("Error: ", e);
-            console.log("Will try again to create Kafka producer in a few seconds.");
-              setTimeout(() => {
-                console.log("Trying again.");
-                this.initKafkaConfiguration(config, callback, "producer");
-              }, 10000);
-          });
-          console.log("... Kafka producer created and callbacks registered.");
-        } else {
-          console.log("Data broker is not Kafka. Skipping producer creation.");
-          this.isProducerReady = true;
-          this.initKafkaConfiguration(config, callback, "consumer");
+      // Kafka producer events registration
+      this.producer.on("ready", () => {
+        console.log("... Kafka producer creation finished.");
+        this.isProducerReady = true;
+      });
+      this.producer.on("error", (e) => {
+        if (isScheduled == true) {
+          console.log("An operation was already scheduled. No need to do it again.");
+          return;
         }
-        break;
-      case "consumer":
-        console.log("Creating new Kafka client...");
-        // First try
-        // Creating consumer client - from device manager to iotagent.
-        // This is always used.
-        console.log("Creating Kafka consumer...");
-        this.getPublishTopic('admin', config.device_manager.inputSubject, (err?:any, topic?: string) => {
-          if (err || (topic == undefined)) {
-            console.error('Failed to retrieve input topic');
-            process.exit(1);
-          }
-
-          this.consumer = new kafka.ConsumerGroup(config.device_manager.consumerOptions, topic!);
-
-          // Kafka consumer events registration
-          this.consumer.on("message", (data) => {
-            let parsedData = JSON.parse(data.value.toString());
-            callback(parsedData);
-          });
-          this.consumer.on("error", (err) => {
-            if (isScheduled == true) {
-              console.log("An operation was already scheduled. No need to do it again.");
-              return;
-            }
-            console.log("Closing current consumer.");
-            this.consumer.close(true, (e) => {
-              console.log("Result of consumer close operation: " + e);
-            });
-
-            isScheduled = true;
-            console.log("Error: ", err);
-            console.log("Will try again to create Kafka consumer in a few seconds.");
-            setTimeout(() => {
-              console.log("Trying again.");
-              this.initKafkaConfiguration(config, callback, "consumer");
-            }, 10000)
-          });
-
-          console.log("... Kafka consumer created and callbacks registered.");
-        })
-        break;
+        this.producer.close();
+        isScheduled = true;
+        console.error("Error: ", e);
+        console.log("Will try again to create Kafka producer in a few seconds.");
+          setTimeout(() => {
+            console.log("Trying again.");
+            this.initDataProducer();
+          }, 10000);
+      });
+      console.log("... Kafka producer created and callbacks registered.");
     }
+  }
+
+  /**
+   * Generates a JWT for usage on internal requests
+   * @param  tenant Tenancy context to be used
+   * @return        JWT token string
+   */
+  private generateJWT(tenant: string) {
+    const payload = {
+      'service': tenant,
+      'username': 'iotagent'
+    }
+    return (new Buffer('dummy jwt schema').toString('base64')) + '.'
+           + (new Buffer(JSON.stringify(payload)).toString('base64')) + '.'
+           + (new Buffer('dummy signature').toString('base64'));
   }
 
   /**
@@ -139,29 +203,20 @@ export class KafkaHandler implements DataBroker {
    * @param  callback Who to call once a topic is obtained
    * @return void
    */
-  private getPublishTopic(tenant: string, subject: string, callback: (err?: any, topic?:string) => void): void {
+  private getPublishTopic(tenant: string, subject: string,
+                          callback: (err?: any, topic?:string) => void,
+                          global?:boolean): void {
     if (tenant in this.topicMap) {
-      if (subject in this.topicMap[tenant]){
+      if (subject in this.topicMap[tenant]) {
         callback(undefined, this.topicMap[tenant][subject]);
         return;
       }
     }
 
-    function generateJWT() {
-      const payload = {
-        'service': tenant,
-        'username': 'iotagent'
-      }
-      return (new Buffer('dummy jwt schema').toString('base64')) + '.'
-             + (new Buffer(JSON.stringify(payload)).toString('base64')) + '.'
-             + (new Buffer('dummy signature').toString('base64'));
-
-    }
-
     axios({
-      'url': this.contextBroker + '/topic/' + subject,
+      'url': this.contextBroker + '/topic/' + subject + (global ? "?global=true" : ""),
       'method': 'get',
-      'headers': {'authorization': 'Bearer ' + generateJWT()}
+      'headers': {'authorization': 'Bearer ' + this.generateJWT(tenant)}
     }).then((response: AxiosResponse) => {
       if (! (this.topicMap[tenant])) {
         this.topicMap[tenant] = {};


### PR DESCRIPTION
This changes iotagent implementation to use topics provided by data-broker for a given subject, within a tenant. That is used to keep a tenant's devices data and metadata isolated from the others, allowing us to make better reuse of such queues.

Apart from that, this also changes the consumer implementation for the newer `ConsumerGroup`. Doing so dramatically improved iotagent's recovery times on subscriptions made to kafka (most notably the one to receive device information from device manager).

This is connected to dojot/dojot#135